### PR TITLE
Fix code scanning alert #12: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/match/lib/match/storage/gitlab/secure_file.rb
+++ b/match/lib/match/storage/gitlab/secure_file.rb
@@ -39,7 +39,7 @@ module Match
 
             create_subfolders(working_directory)
             File.open(destination_file, "wb") do |saved_file|
-              URI.open(url, "rb", { @client.authentication_key => @client.authentication_value }) do |data|
+              URI(url).open("rb", { @client.authentication_key => @client.authentication_value }) do |data|
                 saved_file.write(data.read)
               end
 


### PR DESCRIPTION
Fixes [https://github.com/MacPaw/fastlane/security/code-scanning/12](https://github.com/MacPaw/fastlane/security/code-scanning/12)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
