### PR TITLE
Fix code scanning alert #10: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -7,7 +7,7 @@ require 'fastlane/version'
 # Copy over the latest .rubocop.yml style guide
 require 'yaml'
 rubocop_config = File.expand_path('../.rubocop.yml', __FILE__)
-config = YAML.safe_load(open(rubocop_config))
+config = YAML.safe_load(File.open(rubocop_config))
 config['require'] = [
   'rubocop/require_tools',
   'rubocop-performance'


### PR DESCRIPTION
Fixes [https://github.com/MacPaw/fastlane/security/code-scanning/10](https://github.com/MacPaw/fastlane/security/code-scanning/10)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
