### PR TITLE
Fix code scanning alert #89: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -1,6 +1,6 @@
 require_relative 'module'
 require 'spaceship'
-require 'open-uri'
+require 'net/http'
 
 module Deliver
   class DownloadScreenshots
@@ -68,9 +68,15 @@ module Deliver
           end
 
           path = File.join(containing_folder, file_name)
-          File.binwrite(path, URI.open(url).read)
+          File.binwrite(path, fetch_url_content(url))
         end
       end
+    end
+    def self.fetch_url_content(url)
+      uri = URI(url)
+      response = Net::HTTP.get_response(uri)
+      raise "Failed to fetch URL: #{url}" unless response.is_a?(Net::HTTPSuccess)
+      response.body
     end
   end
 end


### PR DESCRIPTION
Fixes [https://github.com/MacPaw/fastlane/security/code-scanning/89](https://github.com/MacPaw/fastlane/security/code-scanning/89)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
