### PR TITLE
Fix code scanning alert #11: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/fastlane/lib/fastlane/auto_complete.rb
+++ b/fastlane/lib/fastlane/auto_complete.rb
@@ -45,7 +45,7 @@ module Fastlane
         custom_commands = options.custom.to_s.split(',')
 
         Fastlane::SHELLS.each do |shell_name|
-          open("#{fastlane_conf_dir}/completions/completion.#{shell_name}", 'a') do |file|
+          File.open("#{fastlane_conf_dir}/completions/completion.#{shell_name}", 'a') do |file|
             default_line_prefix = Helper.bundler? ? "bundle exec " : ""
 
             file.puts(self.get_auto_complete_line(shell_name, "#{default_line_prefix}fastlane"))


### PR DESCRIPTION
Fixes [https://github.com/MacPaw/fastlane/security/code-scanning/11](https://github.com/MacPaw/fastlane/security/code-scanning/11)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
