### PR TITLE
security: pin pull_request_target actions to SHA

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Communicate on PR merged
         if: github.event.pull_request.merged
-        uses: fastlane/github-actions/communicate-on-pull-request-merged@latest
+        uses: fastlane/github-actions/communicate-on-pull-request-merged@52dd2fec4d387d39806e669e4a12a2aacf7935f7 # latest as of 2026-05-20
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-comment: >

--- a/.github/workflows/pull_request_labeler.yml
+++ b/.github/workflows/pull_request_labeler.yml
@@ -13,4 +13,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6


### PR DESCRIPTION
## Summary

- Pins `fastlane/github-actions/communicate-on-pull-request-merged` from `@latest` to a specific commit SHA
- Pins `actions/labeler` from mutable tag `@v6` to a specific commit SHA

## Why

Both workflows use `pull_request_target`, which runs with the base repository's write-scoped `GITHUB_TOKEN`. Mutable tags (`@latest`, `@v6`) can be silently redirected to malicious commits — a technique actively exploited in the wild ([recent GitHub Actions supply chain attacks](https://thehackernews.com/2026/05/github-actions-supply-chain-attack.html)).

`@latest` is the highest-risk variant: any push to `fastlane/github-actions` immediately affects this workflow with no review.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/pull-requests.yml` | `communicate-on-pull-request-merged@latest` → pinned SHA |
| `.github/workflows/pull_request_labeler.yml` | `actions/labeler@v6` → pinned SHA |

## Test plan

- [ ] Merge a test PR — confirmation comment should still be posted
- [ ] Open a test PR — labels should still be applied by labeler

🤖 Generated with [Claude Code](https://claude.com/claude-code)